### PR TITLE
Connect delete command

### DIFF
--- a/bin/jam
+++ b/bin/jam
@@ -247,6 +247,7 @@ def main():
     try:
         return {
             'create': jam_create,
+            'delete': jam_delete,
             'info': jam_info,
             'help': jam_help,
             'list': jam_list,


### PR DESCRIPTION
`jam delete` was not available via the CLI; this reconnects existing functionality.