### PR TITLE
Add optional context to InvalidSchema exceptions

### DIFF
--- a/jam/exceptions.py
+++ b/jam/exceptions.py
@@ -138,8 +138,11 @@ class InvalidSchema(JamException):
     title = 'Invalid schema'
     status = http.client.BAD_REQUEST
 
-    def __init__(self, type_):
-        super().__init__(detail='The supplied data was an invalid {} schema'.format(type_))
+    def __init__(self, type_, context=None):
+        detail = 'The supplied data was an invalid {} schema'.format(type_)
+        if context:
+            detail += '. Original validation error:\n "{reason}" \n at path: {path}'.format(**context)
+        super().__init__(detail=detail)
 
 
 class InvalidPermission(JamException):

--- a/jam/schemas/jsonschema.py
+++ b/jam/schemas/jsonschema.py
@@ -13,8 +13,11 @@ class JSONSchema(BaseSchema):
     def validate_schema(self, schema):
         try:
             jsonschema.Draft4Validator.check_schema(schema)
-        except jsonschema.SchemaError:
-            raise exceptions.InvalidSchema('jsonschema')
+        except jsonschema.SchemaError as e:
+            raise exceptions.InvalidSchema('jsonschema', {
+                'reason': e.message,
+                'path': '/'.join(e.path)
+            })
 
     def validate(self, data):
         # TODO Translate to custom exceptions


### PR DESCRIPTION
Return the message and path from any exceptions raised from
jsonschema.Draft4Validator.check_schema(schema), and pass into
InvalidSchema exception detail.