### PR TITLE
[rfr] Send user ID to sendgrid, for optional use by email templates

### DIFF
--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -1,2 +1,18 @@
 Contributing
 ============
+
+We welcome contributions via [GitHub](https://github.com/CenterForOpenScience/jamdb).
+
+Before submitting your pull request, please make sure that all unit tests are passing, by running the command below:
+
+.. code:: bash
+
+    behave
+
+To preview changes to the documentation, install the requirements in dev-requirements.txt, then run the following:
+
+.. code:: bash
+
+    cd docs
+    make html
+

--- a/features/steps/plugins.py
+++ b/features/steps/plugins.py
@@ -19,8 +19,11 @@ def assert_called(context):
     if actual.get('from'):
         mail.set_from(actual.get('from'))
 
-    token = mail.add_substitution.call_args[0][1]
-    mail.add_substitution.assert_called_with(':token', token)
+    token = mail.add_substitution.call_args_list[0][0][1]
+    mail.add_substitution.assert_any_call(':token', token)
+
+    user = mail.add_substitution.call_args_list[1][0][1]
+    mail.add_substitution.assert_any_call(':user', user)
 
     mail.add_filter.assert_any_call('templates', 'enable', 1)
     mail.add_filter.assert_any_call('templates', 'template_id', actual['template'])

--- a/jam/plugins/user.py
+++ b/jam/plugins/user.py
@@ -198,10 +198,11 @@ class UserPlugin(Plugin):
 
             mail.set_from(self.from_email)
             mail.add_substitution(':token', user.token.decode())
+            mail.add_substitution(':user', user.id)
             mail.add_filter('templates', 'enable', 1)
             mail.add_filter('templates', 'template_id', self.template)
             # Sendgrid requires subject text and html to be set to a non falsey value
-            # Its highly recommened that you overwrite these in your own templates
+            # It is highly recommended that you overwrite these in your own templates
             mail.set_subject('JamDB password reset')
             mail.set_text('Your temporary token is :token')
             mail.set_html('Your temporary token is :token')


### PR DESCRIPTION
Ticket: https://openscience.atlassian.net/browse/LEI-237

# Purpose
Allow password reset / new user emails from JamDB to  reference the user associated with this action.

Previously, the only variable available to sendgrid was the token.

# Checklist
Behavior:
- [x]  Include correct user id (eg "abought1") in email templates
- [x] Sendgrid can act on this substitution in templates, where appropriate
- [x] Sendgrid can ignore unused substitutions, where appropriate
- [x] Verify emails are correctly formatted and display values as expected

Documentation
- [x] Get unit tests passing
- [x] Document how to contribute and how to run tests

# How to test this
- Create a JamDB project with an accounts collection. Add the following attributes to the collection to enable login and email behaviors (providing your own sendgrid key and template ID as appropriate)
```
    attrs: {
        ...
      schema: {
        "type": "jsonschema",
        "schema": {
          "type": "object",
          "required": [
            "password"
          ],
          "id": "/",
          "properties": {
            "password": {
              "id": "password",
              "pattern": "^\\$2b\\$1[0-3]\\$\\S{53}$",
              "type": "string"
            }
          }
        }
      },
...
        plugins: {
            user: {
              fromEmail: "spammer-catapult@nospam.com",
              sendgridKey: "SG.DangerWillRobinson",
              createdIsOwner: true,
              template: "a-b-c-d-e"
            }
      },
    }
```


A sample SendGrid template would be:
```
Hi, :unspecifiedsubst ,

Your user id is:  :user

You have a token, but this email doesn't tell you what it is. In conclusion, yay dinosaurs!
 
```

Then send a password request- if you use Lookit, the app will do this for you. The email should contain the user ID ("abought1") for the relevant account in place of the `:user` field.